### PR TITLE
Issue #2949940 by tbfisher: View fields searchable does not work for fields with underscores in field name

### DIFF
--- a/listjs.module
+++ b/listjs.module
@@ -72,7 +72,7 @@ function template_preprocess_listjs(&$variables) {
 
           // Prepare row classes.
           if ($field->options['element_default_classes']) {
-            $classes = 'views-field views-field-' . $field->field;
+            $classes = 'views-field views-field-' . drupal_html_class($field->field);
           }
           if ($field_classes = $field->element_classes($id)) {
             if (!empty($classes)) {


### PR DESCRIPTION
making view fields search-able  does not work for fields with underscores in field name (e.g. for nodes not title or body) 

just need to run the class name through drupal_html_class() to convert underscores to dashes.